### PR TITLE
Removes Scala library as IVY dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,6 @@ lazy val macros = (project in file("macros"))
   .settings(Modules.macroSettings: _*)
 
 lazy val root = (project in file("."))
-    .settings(Commons.settings: _*)
-    .settings(Modules.rootSettings: _*)
+  .settings(Commons.settings: _*)
+  .settings(Modules.rootSettings: _*)
   .aggregate(macros)

--- a/project/Modules.scala
+++ b/project/Modules.scala
@@ -11,9 +11,16 @@ object Modules {
 
   val macroSettings = Seq(
     name := "BellTower-macros",
-    libraryDependencies <+=  (scalaVersion)("org.scala-lang" % "scala-compiler" % _),
-    libraryDependencies ++= Seq("joda-time" % "joda-time" % "2.9.3",
-      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full))
+
+    ivyConfigurations += config("compileonly").hide,
+    libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _ % "compileonly"),
+    unmanagedClasspath in Compile ++= update.value.select(configurationFilter("compileonly")),
+    autoScalaLibrary := false,
+
+    libraryDependencies ++= Seq(
+      "joda-time" % "joda-time" % "2.9.3",
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    )
   )
 
 }


### PR DESCRIPTION
@esthom, @pjazdzewski1990: take a look, I've managed to remove Scala libraries as dependency in pom.xml file generated by `publishLocal` task. Check if that hasn't broken anything.
